### PR TITLE
Add web dir variable and update ffmpeg.

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -41,7 +41,7 @@ RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         jellyfin-server=${VERSION} \
         jellyfin-web \
-        jellyfin-ffmpeg && \
+        jellyfin-ffmpeg5 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -32,7 +32,7 @@ RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         jellyfin-server=${VERSION} \
         jellyfin-web \
-        jellyfin-ffmpeg && \
+        jellyfin-ffmpeg5 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \

--- a/root/etc/services.d/jellyfin/run
+++ b/root/etc/services.d/jellyfin/run
@@ -3,9 +3,11 @@
 
 umask "${UMASK}"
 
-[[ -z ${JELLYFIN_CONFIG_DIR} ]] && JELLYFIN_CONFIG_DIR="${CONFIG_DIR}"      && export JELLYFIN_CONFIG_DIR
-[[ -z ${JELLYFIN_DATA_DIR} ]]   && JELLYFIN_DATA_DIR="${CONFIG_DIR}/data"   && export JELLYFIN_DATA_DIR
-[[ -z ${JELLYFIN_LOG_DIR} ]]    && JELLYFIN_LOG_DIR="${CONFIG_DIR}/log"     && export JELLYFIN_LOG_DIR
-[[ -z ${JELLYFIN_CACHE_DIR} ]]  && JELLYFIN_CACHE_DIR="${CONFIG_DIR}/cache" && export JELLYFIN_CACHE_DIR
+[[ -z ${JELLYFIN_CONFIG_DIR} ]]  && JELLYFIN_CONFIG_DIR="${CONFIG_DIR}"         && export JELLYFIN_CONFIG_DIR
+[[ -z ${JELLYFIN_DATA_DIR} ]]    && JELLYFIN_DATA_DIR="${CONFIG_DIR}/data"      && export JELLYFIN_DATA_DIR
+[[ -z ${JELLYFIN_LOG_DIR} ]]     && JELLYFIN_LOG_DIR="${CONFIG_DIR}/log"        && export JELLYFIN_LOG_DIR
+[[ -z ${JELLYFIN_CACHE_DIR} ]]   && JELLYFIN_CACHE_DIR="${CONFIG_DIR}/cache"    && export JELLYFIN_CACHE_DIR
+[[ -z ${JELLYFIN_WEB_DIR} ]]     && JELLYFIN_WEB_DIR="/usr/share/jellyfin/web"  && export JELLYFIN_WEB_DIR
 
-exec s6-setuidgid hotio "/usr/bin/jellyfin" --ffmpeg="/usr/lib/jellyfin-ffmpeg/ffmpeg" --webdir="/usr/share/jellyfin/web"
+
+exec s6-setuidgid hotio "/usr/bin/jellyfin" --ffmpeg="/usr/lib/jellyfin-ffmpeg/ffmpeg"


### PR DESCRIPTION
Changing the web dir is needed for some plugins such as the [intro skipper plugin](https://github.com/ConfusedPolarBear/intro-skipper), I've also updated from jellyfin-ffmpeg to jellyfin-ffmpeg5 which ships version 5.0.1 which is required for said plugin. I've been using this version of ffmpeg for a few days locally and not had any issues with it.