### PR TITLE
Add intel-opencl-icd to image

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -11,6 +11,7 @@ VOLUME ["${CONFIG_DIR}"]
 RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         nvidia-opencl-icd-340 \
+        intel-opencl-icd \
         i965-va-driver \
         mesa-va-drivers && \
 # clean up


### PR DESCRIPTION
Allows OpenCL-based tone mapping using via QSV / VAAPI

Similar to https://github.com/jellyfin/jellyfin/blame/v10.8.10/Dockerfile#L46 but uses the system package.
Tested by running 
```
docker exec -it jellyfin /usr/lib/jellyfin-ffmpeg/ffmpeg -v verbose -init_hw_device vaapi=va -init_hw_device opencl@va
```
where `jellyfin` is a running container.

Before the change the output is
```
[AVHWDeviceContext @ 0x56121a7abd40] Failed to get number of OpenCL platforms: -1001.
Device creation failed: -19.
Failed to set value 'opencl@va' for option 'init_hw_device': No such device
```

After the change the output is
```
[AVHWDeviceContext @ 0x55d3efbdfd40] Intel QSV to OpenCL mapping function found (clCreateFromVA_APIMediaSurfaceINTEL).
[AVHWDeviceContext @ 0x55d3efbdfd40] Intel QSV in OpenCL acquire function found (clEnqueueAcquireVA_APIMediaSurfacesINTEL).
[AVHWDeviceContext @ 0x55d3efbdfd40] Intel QSV in OpenCL release function found (clEnqueueReleaseVA_APIMediaSurfacesINTEL).
```