### PR TITLE
version bump: `jellyfin-ffmpeg6`

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && \
         ocl-icd-libopencl1 \
         jellyfin-server=${VERSION} \
         jellyfin-web \
-        jellyfin-ffmpeg5 && \
+        jellyfin-ffmpeg6 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -18,7 +18,7 @@ RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         jellyfin-server=${VERSION} \
         jellyfin-web \
-        jellyfin-ffmpeg5 && \
+        jellyfin-ffmpeg6 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \


### PR DESCRIPTION
Bumps jellyfin-ffmpeg from `5` to `6`. Note that this will break JF builds from before 10.8.10.