### PR TITLE
version bump: jellyfin-ffmpeg6

### DIFF
--- a/linux-amd64.Dockerfile
+++ b/linux-amd64.Dockerfile
@@ -20,7 +20,7 @@ RUN apt update && \
         ocl-icd-libopencl1 \
         jellyfin-server=${VERSION}-unstable \
         jellyfin-web \
-        jellyfin-ffmpeg5 && \
+        jellyfin-ffmpeg6 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \

--- a/linux-arm64.Dockerfile
+++ b/linux-arm64.Dockerfile
@@ -19,7 +19,7 @@ RUN apt update && \
     apt install -y --no-install-recommends --no-install-suggests \
         jellyfin-server=${VERSION}-unstable \
         jellyfin-web \
-        jellyfin-ffmpeg5 && \
+        jellyfin-ffmpeg6 && \
 # clean up
     apt purge -y gnupg && \
     apt autoremove -y && \


### PR DESCRIPTION
Swap to `jellyfin-ffmpeg6` in nightly image